### PR TITLE
Add tooltip explanations for dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
 
   <section id="dashboard" class="dashboard">
     <div class="card climate">
+      <div class="tooltip">Shows how much average global temperatures have risen over time.</div>
       <span class="emoji">🔥</span>
       <h2>Climate</h2>
       <p>Global Temp Rise:</p>
@@ -40,6 +41,7 @@
       <a href="https://www.climate.gov/news-features/understanding-climate/climate-change-global-temperature" target="_blank">View Full Report</a>
     </div>
     <div class="card forests">
+      <div class="tooltip">Map tracking areas of forest loss around the world.</div>
       <span class="emoji">🌳</span>
       <h2>Forests</h2>
       <p>Global Forest Loss Map:</p>
@@ -47,6 +49,7 @@
       <a href="https://www.globalforestwatch.org/" target="_blank">Explore More</a>
     </div>
     <div class="card oceans">
+      <div class="tooltip">Highlights the size and impact of the Great Pacific Garbage Patch.</div>
       <span class="emoji">🌊</span>
       <h2>Oceans</h2>
       <p>Great Pacific Garbage Patch:</p>
@@ -54,11 +57,12 @@
       <a href="https://marinedebris.noaa.gov/great-pacific-garbage-patch" target="_blank">View Details</a>
     </div>
     <div class="card air">
+      <div class="tooltip">Real‑time Air Quality Index for Washington, DC.</div>
       <span class="emoji">🌬️</span>
       <h2>Air Quality</h2>
       <p>Washington, DC AQI: <span id="aqi">Loading...</span></p>
       <a href="https://www.airnow.gov/" target="_blank">See More Cities</a>
-    </div>    
+    </div>
   </section>
 </section>
   <section id="action" class="action-center">

--- a/style.css
+++ b/style.css
@@ -103,15 +103,34 @@ body {
      align-items: flex-start;
      gap: 0.5rem;
      transition: transform 0.2s ease;
+     position: relative;
    }
    
    .card:hover {
      transform: translateY(-5px);
    }
    
-   .card .emoji {
-     font-size: 2rem;
-   }
+  .card .emoji {
+    font-size: 2rem;
+  }
+
+  .card .tooltip {
+    display: none;
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: rgba(0, 0, 0, 0.75);
+    color: #fff;
+    padding: 0.4rem 0.6rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    max-width: 180px;
+    z-index: 10;
+  }
+
+  .card:hover .tooltip {
+    display: block;
+  }
    
    .card a {
      color: #0984E3;


### PR DESCRIPTION
## Summary
- add tooltip text to each dashboard card
- style tooltip overlay and adjust card styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68473747a5f4832a8a3d0ab655050b84