### PR TITLE
Add floating scroll-top button

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,8 @@
   fetchAirNowAQI();
 </script>
 
+  <button id="scrollTopBtn" aria-label="Back to top">↑</button>
+  <script src="main.js"></script>
 </body>
 
 </html>

--- a/main.js
+++ b/main.js
@@ -1,1 +1,13 @@
+const scrollBtn = document.getElementById('scrollTopBtn');
 
+window.addEventListener('scroll', () => {
+  if (window.pageYOffset > 200) {
+    scrollBtn.style.display = 'block';
+  } else {
+    scrollBtn.style.display = 'none';
+  }
+});
+
+scrollBtn.addEventListener('click', () => {
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+});

--- a/style.css
+++ b/style.css
@@ -1,4 +1,8 @@
 /* style.css */
+html {
+  scroll-behavior: smooth;
+}
+
 
 body {
      margin: 0;
@@ -214,4 +218,20 @@ body {
      .action-center, .about {
        padding: 2rem 1rem;
      }
+#scrollTopBtn {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background-color: #00B894;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1rem;
+  border-radius: 50%;
+  font-size: 1.25rem;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  display: none;
+  z-index: 1000;
+}
+
     }


### PR DESCRIPTION
## Summary
- enable smooth scroll behavior on the page
- create a floating "back to top" button
- show the button when scrolling and smoothly return to the top when clicked

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68473734d8b4832aa4484e7f4e28a6fb